### PR TITLE
Bump OpenNMS Integration API from 0.2.1 to 0.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <junit.version>4.12</junit.version>
     <osgi.version>6.0.0</osgi.version>
     <osgi.compendium.version>5.0.0</osgi.compendium.version>
-    <opennms.api.version>0.2.1</opennms.api.version>
+    <opennms.api.version>0.4.1</opennms.api.version>
     <karaf.version>4.1.5</karaf.version>
     <slf4j-api.version>1.7.25</slf4j-api.version>
   </properties>


### PR DESCRIPTION
Bump version of our OpenNMS Integration API to version 0.4.1.