### PR TITLE
Pris 159

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <osgi.version>6.0.0</osgi.version>
     <osgi.compendium.version>5.0.0</osgi.compendium.version>
     <opennms.api.version>0.4.1</opennms.api.version>
-    <karaf.version>4.1.5</karaf.version>
+    <karaf.version>4.3.6</karaf.version>
     <slf4j-api.version>1.7.25</slf4j-api.version>
   </properties>
 

--- a/pris-xls/src/main/java/org/opennms/plugins/pris/xls/XlsSource.java
+++ b/pris-xls/src/main/java/org/opennms/plugins/pris/xls/XlsSource.java
@@ -80,8 +80,16 @@ public class XlsSource implements Source {
 	public static String getStringValueFromCell(Cell cell) {
 		String value = null;
 		switch (cell.getCellTypeEnum()) {
-		case NUMERIC: value = Integer.toString((int)cell.getNumericCellValue());
+		case NUMERIC: 
+					double d = cell.getNumericCellValue();
+					if (d % 1  ==0) {
+						value = Integer.toString((int) d);
+					} else {
+						// prints double with 7 decimal places - suitable for lat/long
+						value =  String.format("%.7f",d);
+					}
 					break;
+
 		case STRING: value = cell.getStringCellValue();
 					break;
 		case BOOLEAN: value = ((Boolean) cell.getBooleanCellValue()).toString();


### PR DESCRIPTION
fixing https://issues.opennms.org/browse/PRIS-159
Pris rounds the Asset_longitude and Asset_latitude fileds to integers when importing a spreadsheet which makes it impossible to import a usable coordinate from an xls spreadsheet